### PR TITLE
Add project: PathPicker

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1116,6 +1116,11 @@ projects:
     docs_url: http://ergonomica.readthedocs.io/
     desc: Cross-platform shell language based on [S-expressions](https://en.wikipedia.org/wiki/S-expression) combined with traditional shell features.
     tags: ["shell", "linux", "windows", "mac"]
+  - name: PathPicker
+    repo_url: https://github.com/facebook/PathPicker
+    home_url: http://facebook.github.io/PathPicker/
+    desc: Shell utility to pick paths from the output of other commands
+    tags: ["shell", "linux", "mac"]
 
 ## Ops
   - name: OpenStack


### PR DESCRIPTION
## Basic info

**Application name**: PathPicker
**Application repo link**: https://github.com/facebook/PathPicker
**Application home link**: http://facebook.github.io/PathPicker/
**Application description**:  PathPicker presents you with a nice UI to select which files you're interested in. After that you can open them in your favorite editor or execute arbitrary commands. 

## Qualifications

- [x] Free software with an online source repository.
- [x] Using Python for a considerable part of their functionality.
- [x] Well-known, or at least prominently used in an identifiable niche.
- [x] Maintained or otherwise demonstrably still functional on relevant platforms.
- [x] An application, not a library or framework.

## Additional notability info

Standard tool used by Facebook engineers.