### PR TITLE
Add project: DrawBot

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -677,6 +677,15 @@ projects:
       - console
       - docker
       - hardware
+  - name: DrawBot
+    repo_url: https://github.com/typemytype/drawbot
+    home_url: http://www.drawbot.com/
+    date_added: 2019-10-18 15:28:00
+    desc: DrawBot is a powerful, free application for MacOSX that invites you to write simple Python scripts to generate two-dimensional graphics.
+    tags:
+      - graphics
+      - drawing
+      - learning
   - name: FreeCAD
     repo_url: https://github.com/FreeCAD/FreeCAD
     fund_url: https://salt.bountysource.com/teams/freecad


### PR DESCRIPTION
Added an entry for DrawBot to projects.yaml

<!--

Thanks for considering contributing to Awesome Python Applications! If
you're not suggesting adding a project, you can stop reading
now and delete the remainder of this template

---

(Please title your PR `"Add project: <project name>"`)

-->


## Basic info

**Application name**: DrawBot
**Application repo link**: https://github.com/typemytype/drawbot
**Application home link**: http://www.drawbot.com/
**Application description**: DrawBot is a powerful, free application for MacOSX that invites you to write simple Python scripts to generate two-dimensional graphics.

## Qualifications

There are a ton of great Python projects out there, but what makes an
application "Awesome™"? Please check that all of the following criteria apply:

- [x] Free software with an online source repository.
- [x] Using Python for a considerable part of their functionality.
- [x] Well-known, or at least prominently used in an identifiable niche.
- [x] Maintained or otherwise demonstrably still functional on relevant platforms.
- [x] An application, not a library or framework.

Note that installability via pip/PyPI and a developer-audience focus
may warrant a higher standard for inclusion, in keeping with the
spirit of the list:
http://sedimental.org/awesome_python_applications.html

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written for an audience not familiar with that project's particular technologies) -->
